### PR TITLE
Make ISpreadsheet an IDisposable

### DIFF
--- a/src/Backsplice.Spreadsheet/ISpreadsheet.cs
+++ b/src/Backsplice.Spreadsheet/ISpreadsheet.cs
@@ -1,6 +1,6 @@
 namespace Backsplice.Spreadsheet;
 
-public interface ISpreadsheet
+public interface ISpreadsheet : IDisposable
 {
     public List<ISheet> Sheets {get; set;}
 


### PR DESCRIPTION
ISpreadsheet is an interface to a spreadsheet file. Implementing IDisposable makes it possible to use a context manager to ensure the resources are cleaned up.